### PR TITLE
Replaced deprecated function from sfa/base.py

### DIFF
--- a/sfa/base.py
+++ b/sfa/base.py
@@ -229,7 +229,7 @@ class Data(ContainerItem):
         for i, row in enumerate(self._df_conds.iterrows()):
             row = row[1]
             list_name = []  # Target names
-            for target in self._df_conds.columns[row.nonzero()]:
+            for target in self._df_conds.columns[row.to_numpy().nonzero()]:
                 list_name.append(target)
             # end of for
             self._names_ptb.append(list_name)


### PR DESCRIPTION
The pandas.Series.nonzero function is now deprecated (see https://pandas-docs.github.io/pandas-docs-travis/reference/api/pandas.Series.nonzero.html). It is replaced by numpy.nonzero (https://numpy.org/devdocs/reference/generated/numpy.nonzero.html) and the recommended course of action is to convert the Series into a numpy object.