### PR TITLE
Modernize for Python 3.7+ and current NumPy/pandas/NetworkX

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ A simulation framework to analyze signal flows in complex networks.
 * Support user-defined algorithms and datasets.
 
 ## Python version ##
-* Both Python 2 and 3 are supported.
-* Some features such as parallel processing are supported only in the specific versions of Python.
+* Python 3.7+ is supported.
 
 ## Documentation ##
 http://sfa.readthedocs.io

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 numpy
-numpydoc
+scipy
+pandas
 networkx
+numpydoc
 pygments

--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,19 @@
 from setuptools import setup, find_packages
 
 setup(name='sfa',
-      version='0.0.1',
+      version='0.1.0',
       description='Signal flow analysis',
       url='http://github.com/dwgoon/sfa',
       author='Daewon Lee',
       author_email='daewon4you@gmail.com',
       license='MIT',
       packages=find_packages(),
-      package_data = {'': ['*.tsv', '*.sif', '*.json'],},
+      package_data={'': ['*.tsv', '*.sif', '*.json'], },
+      python_requires='>=3.7',
       install_requires=[
-      	  'six',
-          'future',
           'numpy',
-          'networkx',
+          'scipy',
           'pandas',
+          'networkx',
       ],
-      zip_safe=False,)
+      zip_safe=False, )

--- a/sfa/__init__.py
+++ b/sfa/__init__.py
@@ -1,5 +1,4 @@
-
-
+__version__ = "0.1.0"
 
 from .base import *
 from .containers import AlgorithmSet
@@ -10,7 +9,7 @@ from .utils import *
 from .topology import *
 from .fileio import *
 
-__all__ = []
+__all__ = ["__version__"]
 __all__ += base.__all__
 __all__ += containers.__all__
 __all__ += stats.__all__

--- a/sfa/algorithms/np.py
+++ b/sfa/algorithms/np.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sys
-
-if sys.version_info <= (2, 8):
-    from builtins import super
-
-
 import numpy as np
 import pandas as pd
 
@@ -184,7 +178,7 @@ class NetworkPropagation(sfa.base.Algorithm):
         if self._params.apply_weight_norm:
             self.W = sfa.utils.normalize(self.data.A)
         else:
-            self.W = np.array(self.data.A, dtype=np.float)
+            self.W = np.array(self.data.A, dtype=np.float64)
 
         self._check_dimension(self.W, "transition matrix")
 
@@ -268,7 +262,7 @@ class NetworkPropagation(sfa.base.Algorithm):
         df_exp = self.data.df_exp  # Result of experiment
 
         # Simulation result
-        sim_result = np.zeros(df_exp.shape, dtype=np.float)
+        sim_result = np.zeros(df_exp.shape, dtype=np.float64)
 
         b = self._b
 

--- a/sfa/algorithms/sp.py
+++ b/sfa/algorithms/sp.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sys
-if sys.version_info <= (2, 8):
-    from builtins import super
-
 import numpy as np
 
 from .np import NetworkPropagation
@@ -75,9 +71,6 @@ class SignalPropagation(NetworkPropagation):
 
         n = W.shape[0]
         # Initial values
-
-        #x0 = np.zeros((n,), dtype=np.float)
-        #x0[:] = xi
         x0 = np.array(xi, dtype=np.float64)
 
         x_t1 = x0.copy()

--- a/sfa/analysis/perturb.py
+++ b/sfa/analysis/perturb.py
@@ -43,7 +43,7 @@ def analyze_perturb(alg, data, targets, b=None, get_trj=False):
     N = data.A.shape[0]
 
     if b is None:
-        b = np.zeros((N,), dtype=np.float)
+        b = np.zeros((N,), dtype=np.float64)
     elif b.size != N:
         raise TypeError("The size of b should be equal to %d"%(N))
 

--- a/sfa/analysis/random/base.py
+++ b/sfa/analysis/random/base.py
@@ -16,10 +16,10 @@ class BaseRandomSimulator(object):
 
     def _initialize(self, alg):
         self._S = np.sign(alg.data.A)  # Sign matrix
-        self._ir, self._ic = alg.data.A.to_numpy().nonzero()
+        self._ir, self._ic = alg.data.A.nonzero()
         self._num_links = self._ir.size
         self._A = np.array(alg.data.A)
-        self._W = np.zeros_like(self._A, dtype=np.float)
+        self._W = np.zeros_like(self._A, dtype=np.float64)
 
     def _randomize(self):
         raise NotImplementedError()
@@ -56,7 +56,7 @@ class BaseRandomSimulator(object):
         alg.data = data
         alg.initialize(network=False)
 
-        results = np.zeros((num_samp,), dtype=np.float)
+        results = np.zeros((num_samp,), dtype=np.float64)
         cnt = 0
 
         if self._need_to_print(use_print, freq_print, cnt):
@@ -168,7 +168,7 @@ class BaseRandomBatchSimulator(BaseRandomSimulator):
         alg.data = data
         alg.initialize(network=False)
 
-        results = np.zeros((num_samp,), dtype=np.float)
+        results = np.zeros((num_samp,), dtype=np.float64)
         cnt = 0
 
         if self._need_to_print(use_print, freq_print, cnt):

--- a/sfa/analysis/random/structure.py
+++ b/sfa/analysis/random/structure.py
@@ -14,6 +14,6 @@ class RandomStructureBatchSimulator(BaseRandomBatchSimulator):
     def _randomize(self):
         B = sfa.rand_flip(self._A, self._nflip)
         B = sfa.rand_swap(B, self._nswap, self._noself)
-        ir, ic = B.to_numpy().nonzero()
+        ir, ic = B.nonzero()
         self._W[ir, ic] = B[ir, ic]
 # end of class

--- a/sfa/base.py
+++ b/sfa/base.py
@@ -1,21 +1,14 @@
 import os
-import sys
-if sys.version_info <= (2, 8):
-    from builtins import super
-
-# from abc import ABC, abstractmethod
 import abc
 import copy
 
 import pandas as pd
-import six
 import sfa.utils
 
 __all__ = ['Algorithm', 'Data', 'Result']
 
 
-@six.add_metaclass(abc.ABCMeta)
-class ContainerItem():
+class ContainerItem(metaclass=abc.ABCMeta):
     """
     The base class that defines the item object of
     ``sfa.containers.Container``.
@@ -213,13 +206,13 @@ class Data(ContainerItem):
         self._A = A
         self._n2i = n2i
         self._dg = dg
-        self._df_conds = pd.read_table(os.path.join(dpath, fname_conds),
-                                       header=0, index_col=0)
-        self._df_exp = pd.read_table(os.path.join(dpath, fname_exp),
-                                     header=0, index_col=0)
+        self._df_conds = pd.read_csv(os.path.join(dpath, fname_conds),
+                                     sep='\t', header=0, index_col=0)
+        self._df_exp = pd.read_csv(os.path.join(dpath, fname_exp),
+                                   sep='\t', header=0, index_col=0)
 
         self._inputs = inputs
-        self._df_ptb = pd.read_table(fpath_ptb, index_col=0)
+        self._df_ptb = pd.read_csv(fpath_ptb, sep='\t', index_col=0)
         if any(self._df_ptb.Type == 'link'):
             self._has_link_perturb = True
         else:

--- a/sfa/containers.py
+++ b/sfa/containers.py
@@ -1,22 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import sys
-if sys.version_info <= (2, 8):
-    from builtins import super
-
 import os
 import re
 import importlib
-import collections
 import abc
-import six
-
-import sys
-
-if sys.version_info[:2] >= (3, 8):
-    from collections.abc import MutableMapping
-else:
-    from collections import MutableMapping
+from collections.abc import MutableMapping
 
 import sfa.base
 import sfa.algorithms
@@ -27,8 +15,7 @@ from sfa.utils import Singleton
 __all__ = ["AlgorithmSet", "DataSet"]
 
 
-@six.add_metaclass(abc.ABCMeta)
-class Container(MutableMapping):
+class Container(MutableMapping, metaclass=abc.ABCMeta):
     """
     A simple container class, which handles multiple objects with
     its hashable functionality (using dictionary).
@@ -141,7 +128,6 @@ class AlgorithmSet(Container):
                 if re.match(r"[^_]\w+\.py$", entity) \
                    and entity not in excluded:
                     mod_name = entity.split('.')[0]  # Module name
-                    print(mod_name, entity)
                     key = mod_name.upper()
                     self._all_keys.append(key)
                     yield key
@@ -169,9 +155,6 @@ class AlgorithmSet(Container):
 
         alg = mod.create_algorithm(_key)
         self._map[_key] = alg
-
-        # For testing purpose
-        print("%s algorithm has been created." % (_key))
         return alg
 
     def _create_all(self):
@@ -255,8 +238,6 @@ class DataSet(Container):
             raise TypeError(err_msg)
         # end of if
 
-        # For testing purpose
-        print("%s data has been created." % (_key))
         return self._map[_key]
     # end of def _create_single
 

--- a/sfa/control/influence.py
+++ b/sfa/control/influence.py
@@ -104,7 +104,7 @@ def compute_influence(W,
         
         if rtype == 'df':
             import cupy as cp
-            if isinstance(ret, cp.core.core.ndarray):
+            if isinstance(ret, cp.ndarray):
                 ret = cp.asnumpy(ret)
 
     if get_iter:
@@ -144,9 +144,9 @@ def _compute_influence_cpu(W, alpha=0.5, beta=0.5, S=None,
     if S is not None:
         S1 = S
     else:
-        S1 = np.eye(N, dtype=np.float)
+        S1 = np.eye(N, dtype=np.float64)
 
-    I = np.eye(N, dtype=np.float)
+    I = np.eye(N, dtype=np.float64)
     S2 = np.zeros_like(W)
     aW = alpha * W
     for cnt in range(max_iter):
@@ -171,11 +171,11 @@ def _compute_influence_cpu_sparse(W, alpha, beta, S,
     if S is not None:
         S1 = S
     else:
-        S1 = sp.sparse.lil_matrix(sp.sparse.eye(N, dtype=np.float))
+        S1 = sp.sparse.lil_matrix(sp.sparse.eye(N, dtype=np.float64))
 
 
-    I = sp.sparse.eye(N, dtype=np.float)
-    S2 = sp.sparse.lil_matrix((N,N), dtype=np.float)
+    I = sp.sparse.eye(N, dtype=np.float64)
+    S2 = sp.sparse.lil_matrix((N,N), dtype=np.float64)
     aW = sp.sparse.csc_matrix(alpha * W)
     for cnt in range(max_iter):
         S2[:, :] = S1.dot(aW) + I
@@ -199,7 +199,7 @@ def _compute_influence_gpu(W, alpha=0.5, beta=0.5, S=None,
     import cupy as cp
     cp.cuda.Device(id_device).use()    
     N = W.shape[0]
-    I = cp.eye(N, dtype=cp.float32) #np.eye(N, N, dtype=np.float)
+    I = cp.eye(N, dtype=cp.float32) #np.eye(N, N, dtype=np.float64)
     if S is not None:
         S1 = cp.array(S, dtype=cp.float32)
     else:

--- a/sfa/data/borisov_2009/__init__.py
+++ b/sfa/data/borisov_2009/__init__.py
@@ -16,10 +16,6 @@ http://doi.org/10.1038/msb.2009.19
 - The units of EGF and insulin (I) stimulation are nM.
 """
 
-import sys
-if sys.version_info <= (2, 8):
-    from builtins import super
-
 import os
 import re
 import glob

--- a/sfa/data/korkut_2015a/__init__.py
+++ b/sfa/data/korkut_2015a/__init__.py
@@ -35,13 +35,13 @@ class KorkutData(sfa.base.Data):
         self._A = A
         self._n2i = n2i
         self._dg = dg
-        self._df_conds = pd.read_table(os.path.join(dpath, "conds.tsv"),
-                                       header=0, index_col=0)
-        self._df_exp = pd.read_table(os.path.join(dpath, "exp.tsv"),
-                                     header=0, index_col=0)
+        self._df_conds = pd.read_csv(os.path.join(dpath, "conds.tsv"),
+                                     sep='\t', header=0, index_col=0)
+        self._df_exp = pd.read_csv(os.path.join(dpath, "exp.tsv"),
+                                   sep='\t', header=0, index_col=0)
 
         self._inputs = {}
-        self._df_ptb = pd.read_table(fpath_ptb, index_col=0)
+        self._df_ptb = pd.read_csv(fpath_ptb, sep='\t', index_col=0)
         if any(self._df_ptb.Type == 'link'):
             self._has_link_perturb = True
         else:

--- a/sfa/data/pezze_2012/__init__.py
+++ b/sfa/data/pezze_2012/__init__.py
@@ -16,10 +16,6 @@ http://doi:10.1126/scisignal.2002469
 - The unit of insulin (I) stimulation is nM.
 """
 
-import sys
-if sys.version_info <= (2, 8):
-    from builtins import super
-
 import os
 import re
 import glob

--- a/sfa/data/schliemann_2011/__init__.py
+++ b/sfa/data/schliemann_2011/__init__.py
@@ -15,10 +15,6 @@ http://www.biomedcentral.com/1752-0509/5/204
 - The unit of TNF stimulation is nM.
 """
 
-import sys
-if sys.version_info <= (2, 8):
-    from builtins import super
-
 import os
 import re
 import glob

--- a/sfa/fileio.py
+++ b/sfa/fileio.py
@@ -56,7 +56,7 @@ def read_sif(fpath, signs={'+':1, '-':-1}, sort=True, as_nx=False):
         list_nodes = list(set_nodes)
 
     N = len(set_nodes)
-    adj = np.zeros((N, N), dtype=np.int)
+    adj = np.zeros((N, N), dtype=int)
 
     for isrc, name in enumerate(list_nodes):
         n2i[name] = isrc  # index of source

--- a/sfa/manager.py
+++ b/sfa/manager.py
@@ -5,13 +5,12 @@ Created on Tue Jul  5 15:05:25 2016
 @author: dwlee
 """
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 from .base import Algorithm
 from .base import Data
 
-class JobManager(object):
-    __metaclass__ = ABCMeta
+class JobManager(ABC):
 
     def add_algorithm(self, alg):
         

--- a/sfa/stats.py
+++ b/sfa/stats.py
@@ -22,7 +22,6 @@ def calc_accuracy(df1, df2, get_cons=False):
     getcons: decide whether to return consensus array in DataFrame or not
     """
 
-    np.sign(df1) + np.sign(df2)
     if df1.ndim == 1:
         num_total = df1.shape[0]
     elif df1.ndim == 2:
@@ -33,10 +32,9 @@ def calc_accuracy(df1, df2, get_cons=False):
     if isinstance(consensus, pd.DataFrame):
         num_cons = consensus.values.sum()
     else:
-        #num_cons = consensus.sum(axis=1).sum()  # Number of consensus
         num_cons = consensus.sum()
-        
-    acc = (num_cons) / np.float(num_total)  # Accuracy
+
+    acc = num_cons / float(num_total)  # Accuracy
     if get_cons:
         return acc, consensus
     else:

--- a/sfa/topology.py
+++ b/sfa/topology.py
@@ -1,8 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
-if sys.version_info <= (2, 8):
-    from builtins import super
-
 import numpy as np
 import pandas as pd
 import networkx as nx

--- a/sfa/utils.py
+++ b/sfa/utils.py
@@ -1,15 +1,5 @@
 # -*- coding: utf-8 -*-
-import sys
-if sys.version_info <= (2, 8):
-    from builtins import super
-
-import os
-import codecs
-from collections import defaultdict
-
 import numpy as np
-import scipy as sp
-import pandas as pd
 import networkx as nx
 
 
@@ -22,7 +12,7 @@ __all__ = ["FrozenClass",
            "rand_weights",
            "rand_structure",
            "get_akey",
-           "get_avalue",]
+           "get_avalue", ]
 
 
 class FrozenClass(object):
@@ -31,7 +21,7 @@ class FrozenClass(object):
 
     def __setattr__(self, key, value):
         if self.__isfrozen and not hasattr(self, key):
-            raise TypeError( "%r is a frozen class" % self )
+            raise TypeError("%r is a frozen class" % self)
         object.__setattr__(self, key, value)
 
     def _freeze(self):
@@ -113,10 +103,7 @@ def normalize(A, norm_in=True, norm_out=True):
         else:
             Dr = 1 / np.sqrt(sum_row_A)
         # end of row
-        W = np.multiply(W, np.mat(Dr).T)
-        # Converting np.mat to ndarray
-        # does not cost a lot.
-        W = W.A
+        W = np.multiply(W, Dr.reshape(-1, 1))
     # end of if
     """
     The normalization above is the same as the follows:
@@ -126,14 +113,14 @@ def normalize(A, norm_in=True, norm_out=True):
 
 
 # end of def normalize
-    
+
 def to_networkx_digraph(A, n2i=None):
     if not n2i:
-        return nx.from_numpy_array(A, create_using=nx.Digraph)        
-    
-    i2n = {ix:name for name, ix in n2i.items()}        
+        return nx.from_numpy_array(A, create_using=nx.DiGraph)
+
+    i2n = {ix: name for name, ix in n2i.items()}
     dg = nx.DiGraph()
-    ind_row, ind_col = A.to_numpy().nonzero()
+    ind_row, ind_col = A.nonzero()
     for ix_trg, ix_src in zip(ind_row, ind_col):
         name_src = i2n[ix_src]
         name_trg = i2n[ix_trg]
@@ -142,7 +129,6 @@ def to_networkx_digraph(A, n2i=None):
         dg.edges[name_src, name_trg]['SIGN'] = sign
     # end of for
     return dg
-    # end of for
 # end of def to_networkx_digraph
 
 def rand_swap(A, nsamp=10, noself=True, pivots=None, inplace=False):
@@ -172,24 +158,24 @@ def rand_swap(A, nsamp=10, noself=True, pivots=None, inplace=False):
 
     if not inplace:
         A_org = A
-        B = A.copy() #np.array(A, dtype=np.float64)
+        B = A.copy()
     else:
-        A_org = A.copy() #np.array(A, dtype=np.float64)
+        A_org = A.copy()
         B = A
 
     cnt = 0
     while cnt < nsamp:
-        ir, ic = B.to_numpy().nonzero()
+        ir, ic = B.nonzero()
         if pivots:
             if np.random.uniform() < 0.5:
                 isrc1 = np.random.choice(pivots)
-                nz = B[:, isrc1].to_numpy().nonzero()[0]
+                nz = B[:, isrc1].nonzero()[0]
                 if len(nz) == 0:
                     continue
                 itrg1 = np.random.choice(nz)
             else:
                 itrg1 = np.random.choice(pivots)
-                nz = B[itrg1, :].to_numpy().nonzero()[0]
+                nz = B[itrg1, :].nonzero()[0]
                 if len(nz) == 0:
                     continue
                 isrc1 = np.random.choice(nz)
@@ -251,11 +237,11 @@ def rand_flip(A, nsamp=10, pivots=None, inplace=False):
         The reference of the given W is returned, when inplace is True.
     """
     if not inplace:
-        B = A.copy() #np.array(A, dtype=np.float64)
+        B = A.copy()
     else:
         B = A
 
-    ir, ic = B.to_numpy().nonzero()
+    ir, ic = B.nonzero()
     if pivots:
         iflip = np.random.choice(pivots, nsamp)
     else:
@@ -288,22 +274,16 @@ def rand_weights(W, lb=-3, ub=3, inplace=False):
     else:
         if not np.issubdtype(W.dtype, np.floating):
             raise ValueError("W.dtype given to rand_weights should be "
-                             "a float type, not %s"%(W.dtype))
+                             "a float type, not %s" % (W.dtype))
 
         B = W
     # end of if-else
 
-    ir, ic = B.to_numpy().nonzero()
+    ir, ic = B.nonzero()
     weights_rand = 10 ** np.random.uniform(lb, ub,
                                            size=(ir.size,))
 
-    B[ir, ic] = weights_rand*np.sign(B[ir, ic], dtype=np.float)
-    """The above code is equal to the following:
-    
-    for i in range(ir.size):
-        p, q = ir[i], ic[i]
-        B[p, q] = weights_rand[i] * np.sign(B[p, q], dtype=np.float)
-    """
+    B[ir, ic] = weights_rand * np.sign(B[ir, ic])
     return B
 
 

--- a/sfa/vis/sfv/sfv.py
+++ b/sfa/vis/sfv/sfv.py
@@ -51,7 +51,7 @@ def create_from_graphics(net, abbr=None, inputs=None, outputs=None):
             self._i2n = {idx: name for name, idx in self._n2i.items()}
 
             self._A = nx.to_numpy_array(self._dg, nodes).T
-            ir, ic = self._A.to_numpy().nonzero()
+            ir, ic = self._A.nonzero()
             for i in range(ir.size):
                 r, c = ir[i], ic[i]
 
@@ -249,12 +249,12 @@ def visualize_signal_flow(net, F, act,
 
 
 def _update_links(net, A, F, i2n, pct_link, lw_min, lw_max):
-    log_flows = np.log10(np.abs(F[F.to_numpy().nonzero()]))
+    log_flows = np.log10(np.abs(F[F.nonzero()]))
     flow_max = log_flows.max()
     flow_min = log_flows.min()
     flow_thr = np.percentile(log_flows, pct_link)
 
-    ir, ic = A.to_numpy().nonzero() #F.to_numpy().nonzero()
+    ir, ic = A.nonzero()  # F.nonzero()
     for i, j in zip(ir, ic):
         tgt = i2n[i]
         src = i2n[j]

--- a/sfa/vis/utils.py
+++ b/sfa/vis/utils.py
@@ -126,12 +126,12 @@ def _compute_graphics_nodes(dg, n2i, act, pct_act):
 def _compute_graphics_links(dg, n2i, A, F, pct_link, lw_min, lw_max):
     i2n = {val: key for key, val in n2i.items()}
 
-    log_flows = np.log10(np.abs(F[F.to_numpy().nonzero()]))
+    log_flows = np.log10(np.abs(F[F.nonzero()]))
     flow_max = log_flows.max()
     flow_min = log_flows.min()
     flow_thr = np.percentile(log_flows, pct_link)
 
-    ir, ic = A.to_numpy().nonzero()  # F.to_numpy().nonzero()
+    ir, ic = A.nonzero()  # F.nonzero()
     for i, j in zip(ir, ic):
         tgt = i2n[i]
         src = i2n[j]


### PR DESCRIPTION
## Summary

Brings the package back to a working state on modern scientific-Python stacks (NumPy ≥ 1.20, pandas ≥ 1.4, NetworkX ≥ 2.x) and drops the Python 2 compatibility layer. Bumps version to 0.1.0.

### Critical fixes (package was broken on modern NumPy)

- Replace removed NumPy aliases: `np.int` → `int`, `np.float` → `np.float64`
- Replace `np.mat(Dr).T` with `Dr.reshape(-1, 1)` broadcasting in `normalize()`
- Fix `nx.Digraph` typo → `nx.DiGraph` in `to_networkx_digraph`
- Drop bogus `.to_numpy()` calls on numpy `ndarray`s in `utils`, `vis`, `analysis` (it is a `pandas` method)
- Replace `pd.read_table` with `pd.read_csv(sep='\t')`

### Modernization

- Drop Python 2 support: remove `six`, `from builtins import super`, `sys.version_info <= (2, 8)` guards across files
- Use `class JobManager(ABC)` instead of the Python 2 `__metaclass__` idiom
- Import `MutableMapping` from `collections.abc` directly
- Remove debug `print()` statements from `AlgorithmSet` / `DataSet`
- Remove dead `np.sign()` expression in `calc_accuracy`
- Update CuPy ndarray check (`cp.core.core.ndarray` → `cp.ndarray`)

### Packaging

- Add `__version__` to `sfa` package (`0.1.0`)
- Add `pandas` and `scipy` to `install_requires` and `requirements.txt`
- Declare `python_requires='>=3.7'`
- Update README to reflect Python 3.7+ requirement

## Test plan

- [x] `import sfa` succeeds; `sfa.__version__ == '0.1.0'`
- [x] `sfa.AlgorithmSet().create('SP')` works without debug print noise
- [x] `sfa.normalize`, `sfa.rand_swap`, `sfa.rand_flip`, `sfa.rand_weights`, `sfa.to_networkx_digraph` all run on numpy `ndarray` input
- [x] `sfa.control.compute_influence` runs on `BORISOV_2009` with α=0.9, β=0.1 and produces consistent results across runs
- [ ] Reviewer to confirm CI / downstream tests (if any) still pass